### PR TITLE
Correct ex1's ungraded exercise's testing data point

### DIFF
--- a/ex1/ex1_multi.py
+++ b/ex1/ex1_multi.py
@@ -80,7 +80,9 @@ print 'Theta computed from gradient descent: '
 print theta
 
 # Estimate the price of a 1650 sq-ft, 3 br house
-price = np.array([1,3,1650]).dot(theta)
+house = np.array([1650, 3])
+house = (house - mu) / sigma
+price = np.hstack((1, house)).dot(theta)
 
 print 'Predicted price of a 1650 sq-ft, 3 br house'
 print '(using gradient descent): '
@@ -119,7 +121,7 @@ print 'Theta computed from the normal equations:'
 print ' %s \n' % theta
 
 # Estimate the price of a 1650 sq-ft, 3 br house
-price = np.array([1, 3, 1650]).dot(theta)
+price = np.array([1, 1650, 3]).dot(theta)
 
 # ============================================================
 


### PR DESCRIPTION
Things modified:
- Testing data point for applying theta produced by gradient descent and normal equation. Originally the order was wrong, square-feet should go first, then number of bedrooms.
- Add feature normalization before applying the theta produced by gradient descent. As described in "Implementation Note" of section 3.1 in `ex1.pdf`, "We must first normalize *x* using the mean and standard deviation that we had previously computed from the training set."